### PR TITLE
Fix SortPath if no offset is specified

### DIFF
--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -246,7 +246,7 @@ def SortPath(wire,Side,radius,clockwise,firstedge=None,SegLen =0.5):
         if wire.isClosed():
             offset = newwire.makeOffset(0.0)
         else:
-            offset = wire
+            offset = newwire
 
     return offset
 


### PR DESCRIPTION
Without this fix, if no offset is specified and wire is
not closed, original wire is used, which leads to using only
two endpoint vertexes for spline and ellipse edges.
